### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ https://kpmg.com/nl/en/home/insights/2024/12/zig-strike-the-ultimate-toolkit-for
 ```
 git clone https://github.com/0xsp-SRD/ZigStrike/
 cd ZigStrike/App/ 
-python3 App.py 
+python3 app.py 
 ```
 
 ## Docker 


### PR DESCRIPTION
Corrected capitalisation of App.py to app.py.

To resolve
```
python3 App.py
python3: can't open file '/root/ZigStrike/App/App.py': [Errno 2] No such file or directory
```